### PR TITLE
Add cross-feed duplicate article detection

### DIFF
--- a/src/article.ts
+++ b/src/article.ts
@@ -1,4 +1,5 @@
 import { db } from "./db";
+import { canonicalizeUrl } from "./dedupe";
 import type { Article, Briefing, BriefingCluster } from "./types";
 
 export type ArticleWithFeed = Article & { feed_title: string | null; category: string | null };
@@ -6,8 +7,8 @@ export type ArticleWithFeed = Article & { feed_title: string | null; category: s
 export function getCuratedArticles(sort: "newest" | "score" = "newest", view: "active" | "archive" = "active"): ArticleWithFeed[] {
   const order = sort === "score" ? "a.score DESC" : "a.published_at DESC, a.fetched_at DESC";
   const whereClause = view === "archive"
-    ? "WHERE a.curated_at IS NOT NULL AND (a.dismissed_at IS NOT NULL OR a.archived_at IS NOT NULL)"
-    : "WHERE a.curated_at IS NOT NULL AND a.dismissed_at IS NULL AND a.archived_at IS NULL";
+    ? "WHERE a.curated_at IS NOT NULL AND a.duplicate_of IS NULL AND (a.dismissed_at IS NOT NULL OR a.archived_at IS NOT NULL)"
+    : "WHERE a.curated_at IS NOT NULL AND a.duplicate_of IS NULL AND a.dismissed_at IS NULL AND a.archived_at IS NULL";
   return db
     .prepare(
       `SELECT a.*, f.title as feed_title, f.category
@@ -26,7 +27,7 @@ export function getActiveArticles(sort: "newest" | "score" = "newest"): ArticleW
       `SELECT a.*, f.title as feed_title, f.category
        FROM articles a
        LEFT JOIN feeds f ON a.feed_id = f.id
-       WHERE a.dismissed_at IS NULL AND a.archived_at IS NULL
+       WHERE a.duplicate_of IS NULL AND a.dismissed_at IS NULL AND a.archived_at IS NULL
        ORDER BY ${order}`
     )
     .all() as ArticleWithFeed[];
@@ -62,14 +63,23 @@ export function addArticle(
   feedId?: number,
   publishedAt?: string
 ): boolean {
+  const canonical = canonicalizeUrl(url);
+
+  // Check if a canonical duplicate already exists (different URL, same canonical)
+  const existing = db.prepare(
+    "SELECT id FROM articles WHERE canonical_url = ? AND url != ?"
+  ).get(canonical, url) as { id: number } | null;
+
   const result = db.prepare(
-    "INSERT OR IGNORE INTO articles (feed_id, url, title, content, published_at) VALUES (?, ?, ?, ?, ?)"
-  ).run(feedId ?? null, url, title ?? null, content ?? null, publishedAt ?? null);
+    "INSERT OR IGNORE INTO articles (feed_id, url, title, content, published_at, canonical_url, duplicate_of) VALUES (?, ?, ?, ?, ?, ?, ?)"
+  ).run(feedId ?? null, url, title ?? null, content ?? null, publishedAt ?? null, canonical, existing?.id ?? null);
   return result.changes > 0;
 }
 
 export function listArticles(uncuratedOnly: boolean = false, limit?: number): Article[] {
-  const where = uncuratedOnly ? "WHERE curated_at IS NULL" : "";
+  const conditions = ["duplicate_of IS NULL"];
+  if (uncuratedOnly) conditions.push("curated_at IS NULL");
+  const where = `WHERE ${conditions.join(" AND ")}`;
   const limitClause = limit ? `LIMIT ${limit}` : "";
   return db
     .prepare(`SELECT * FROM articles ${where} ORDER BY fetched_at DESC ${limitClause}`)

--- a/src/db.ts
+++ b/src/db.ts
@@ -147,6 +147,8 @@ for (const [table, col] of [
   ["feeds", "category TEXT"],
   ["articles", "dismissed_at TEXT"],
   ["articles", "archived_at TEXT"],
+  ["articles", "canonical_url TEXT"],
+  ["articles", "duplicate_of INTEGER REFERENCES articles(id)"],
 ]) {
   try {
     db.exec(`ALTER TABLE ${table} ADD COLUMN ${col}`);
@@ -157,3 +159,5 @@ for (const [table, col] of [
 
 db.exec("CREATE INDEX IF NOT EXISTS idx_articles_dismissed_at ON articles(dismissed_at)");
 db.exec("CREATE INDEX IF NOT EXISTS idx_articles_archived_at ON articles(archived_at)");
+db.exec("CREATE INDEX IF NOT EXISTS idx_articles_canonical_url ON articles(canonical_url)");
+db.exec("CREATE INDEX IF NOT EXISTS idx_articles_duplicate_of ON articles(duplicate_of)");

--- a/src/dedupe.test.ts
+++ b/src/dedupe.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { canonicalizeUrl } from "./dedupe";
+import { db } from "./db";
+import { addFeed, getAllFeeds } from "./feed";
+import { addArticle, listArticles, getCuratedArticles, updateArticleCuration } from "./article";
+
+// ─── canonicalizeUrl ───
+
+describe("canonicalizeUrl", () => {
+  test("strips UTM parameters", () => {
+    expect(
+      canonicalizeUrl("https://example.com/article?utm_source=rss&utm_medium=feed")
+    ).toBe("https://example.com/article");
+  });
+
+  test("strips multiple tracking parameters", () => {
+    expect(
+      canonicalizeUrl("https://example.com/post?fbclid=abc&gclid=def&ref=twitter")
+    ).toBe("https://example.com/post");
+  });
+
+  test("preserves non-tracking parameters", () => {
+    expect(
+      canonicalizeUrl("https://example.com/search?q=hello&utm_source=rss")
+    ).toBe("https://example.com/search?q=hello");
+  });
+
+  test("removes www prefix", () => {
+    expect(
+      canonicalizeUrl("https://www.example.com/article")
+    ).toBe("https://example.com/article");
+  });
+
+  test("lowercases hostname", () => {
+    expect(
+      canonicalizeUrl("https://Example.COM/Article")
+    ).toBe("https://example.com/Article");
+  });
+
+  test("removes fragment", () => {
+    expect(
+      canonicalizeUrl("https://example.com/article#comments")
+    ).toBe("https://example.com/article");
+  });
+
+  test("removes trailing slash", () => {
+    expect(
+      canonicalizeUrl("https://example.com/article/")
+    ).toBe("https://example.com/article");
+  });
+
+  test("preserves trailing slash on root path", () => {
+    expect(
+      canonicalizeUrl("https://example.com/")
+    ).toBe("https://example.com/");
+  });
+
+  test("sorts query parameters for consistency", () => {
+    expect(
+      canonicalizeUrl("https://example.com/search?z=1&a=2")
+    ).toBe("https://example.com/search?a=2&z=1");
+  });
+
+  test("handles invalid URL gracefully", () => {
+    expect(canonicalizeUrl("not-a-url")).toBe("not-a-url");
+  });
+
+  test("identifies same article with different tracking params", () => {
+    const url1 = "https://blog.example.com/post-1?utm_source=rss";
+    const url2 = "https://blog.example.com/post-1?utm_source=twitter&ref=homepage";
+    expect(canonicalizeUrl(url1)).toBe(canonicalizeUrl(url2));
+  });
+
+  test("identifies same article with www vs non-www", () => {
+    const url1 = "https://www.example.com/article";
+    const url2 = "https://example.com/article";
+    expect(canonicalizeUrl(url1)).toBe(canonicalizeUrl(url2));
+  });
+
+  test("does not conflate different articles", () => {
+    const url1 = "https://example.com/article-1";
+    const url2 = "https://example.com/article-2";
+    expect(canonicalizeUrl(url1)).not.toBe(canonicalizeUrl(url2));
+  });
+});
+
+// ─── Cross-feed dedup integration ───
+
+function clearAll(): void {
+  db.prepare("DELETE FROM briefings").run();
+  db.prepare("DELETE FROM articles").run();
+  db.prepare("DELETE FROM feeds").run();
+}
+
+describe("cross-feed duplicate detection", () => {
+  beforeEach(clearAll);
+
+  test("articles with same canonical URL are linked via duplicate_of", () => {
+    addFeed("https://feed-a.com/rss", "Feed A");
+    addFeed("https://feed-b.com/rss", "Feed B");
+    const feeds = getAllFeeds();
+
+    // First article inserted normally
+    addArticle("https://example.com/post?utm_source=feedA", "Post", "content", feeds[0].id);
+    // Second article with same canonical URL should be marked as duplicate
+    addArticle("https://example.com/post?utm_source=feedB", "Post", "content", feeds[1].id);
+
+    const articles = db.prepare("SELECT * FROM articles ORDER BY id").all() as any[];
+    expect(articles).toHaveLength(2);
+    expect(articles[0].duplicate_of).toBeNull();
+    expect(articles[1].duplicate_of).toBe(articles[0].id);
+  });
+
+  test("duplicate articles are excluded from uncurated list", () => {
+    addFeed("https://feed-a.com/rss", "Feed A");
+    addFeed("https://feed-b.com/rss", "Feed B");
+    const feeds = getAllFeeds();
+
+    addArticle("https://example.com/post?ref=a", "Post", "content", feeds[0].id);
+    addArticle("https://example.com/post?ref=b", "Post", "content", feeds[1].id);
+    addArticle("https://example.com/unique", "Unique", "content", feeds[0].id);
+
+    const uncurated = listArticles(true);
+    // Only non-duplicate articles should appear
+    expect(uncurated).toHaveLength(2);
+    expect(uncurated.map(a => a.title)).toContain("Unique");
+  });
+
+  test("duplicate articles are excluded from curated articles list", () => {
+    addFeed("https://feed-a.com/rss", "Feed A");
+    addFeed("https://feed-b.com/rss", "Feed B");
+    const feeds = getAllFeeds();
+
+    addArticle("https://example.com/post?ref=a", "Post A", "content", feeds[0].id);
+    addArticle("https://example.com/post?ref=b", "Post B", "content", feeds[1].id);
+
+    // Curate both
+    const articles = db.prepare("SELECT * FROM articles ORDER BY id").all() as any[];
+    updateArticleCuration(articles[0].id, 0.8, "Summary", "ai");
+    updateArticleCuration(articles[1].id, 0.7, "Summary", "ai");
+
+    const curated = getCuratedArticles("score");
+    // Only the primary (non-duplicate) should appear
+    expect(curated).toHaveLength(1);
+    expect(curated[0].score).toBe(0.8);
+  });
+
+  test("exact same URL is still handled by UNIQUE constraint", () => {
+    addFeed("https://feed-a.com/rss", "Feed A");
+    const feeds = getAllFeeds();
+
+    const first = addArticle("https://example.com/post", "Post", "content", feeds[0].id);
+    const second = addArticle("https://example.com/post", "Post", "content", feeds[0].id);
+
+    expect(first).toBe(true);
+    expect(second).toBe(false); // Rejected by UNIQUE
+
+    const articles = db.prepare("SELECT * FROM articles").all() as any[];
+    expect(articles).toHaveLength(1);
+  });
+});

--- a/src/dedupe.ts
+++ b/src/dedupe.ts
@@ -1,0 +1,60 @@
+/**
+ * Cross-feed duplicate article detection via URL canonicalization.
+ *
+ * Strategy: normalize URLs by stripping tracking parameters, fragments,
+ * and protocol/www differences. Articles with the same canonical URL
+ * are considered duplicates.
+ */
+
+/** UTM and common tracking parameters to strip */
+const TRACKING_PARAMS = new Set([
+  "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+  "ref", "source", "fbclid", "gclid", "mc_cid", "mc_eid",
+]);
+
+/**
+ * Normalize a URL for deduplication.
+ * - Lowercase protocol and hostname
+ * - Remove www. prefix
+ * - Strip tracking/UTM parameters
+ * - Remove fragment
+ * - Remove trailing slash
+ */
+export function canonicalizeUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+
+    // Lowercase protocol and hostname
+    url.protocol = url.protocol.toLowerCase();
+    url.hostname = url.hostname.toLowerCase();
+
+    // Remove www. prefix
+    if (url.hostname.startsWith("www.")) {
+      url.hostname = url.hostname.slice(4);
+    }
+
+    // Strip tracking parameters
+    for (const param of [...url.searchParams.keys()]) {
+      if (TRACKING_PARAMS.has(param.toLowerCase())) {
+        url.searchParams.delete(param);
+      }
+    }
+
+    // Sort remaining params for consistency
+    url.searchParams.sort();
+
+    // Remove fragment
+    url.hash = "";
+
+    // Build canonical URL and remove trailing slash (except for root path)
+    let canonical = url.toString();
+    if (canonical.endsWith("/") && url.pathname !== "/") {
+      canonical = canonical.slice(0, -1);
+    }
+
+    return canonical;
+  } catch {
+    // If URL is invalid, return as-is
+    return rawUrl;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface Article {
   tags: string | null;
   dismissed_at: string | null;
   archived_at: string | null;
+  canonical_url: string | null;
+  duplicate_of: number | null;
 }
 
 export interface BriefingCluster {


### PR DESCRIPTION
## Summary

- URL正規化による クロスフィード重複記事検出を実装
- UTM/トラッキングパラメータ、www、フラグメント、末尾スラッシュを正規化
- 重複記事はキュレーション・ブリーフィング・表示から自動除外

## Design

`canonical_url` カラムで正規化URLを保持し、`duplicate_of` で最初に登録された記事を参照。タイトル類似度マッチングは偽陽性リスクがあるため初期実装では見送り。

## Changes

- `src/dedupe.ts`: URL正規化ロジック（新規）
- `src/db.ts`: `canonical_url`, `duplicate_of` カラム追加
- `src/article.ts`: 挿入時の重複検出、クエリからの重複除外
- `src/types.ts`: Article型にフィールド追加
- `src/dedupe.test.ts`: 17テスト追加

## Test plan

- [x] URL正規化: UTM除去、www除去、フラグメント除去、パラメータソート
- [x] 統合: 異なるURLの同一canonical記事がduplicate_ofでリンクされる
- [x] 統合: 重複記事がuncurated/curated一覧から除外される
- [x] 既存テスト578件全パス

Closes #8